### PR TITLE
PRA-143: update normalizr schemes

### DIFF
--- a/src/modules/comments.js
+++ b/src/modules/comments.js
@@ -1,5 +1,8 @@
 export { default as actions } from 'modules/comments/actions'
 export { default as types } from 'modules/comments/types'
-export { default as sagas } from 'modules/comments/sagas'
 export * from 'modules/comments/selectors'
 export { default as default } from 'modules/comments/reducers'
+
+import { default as sagas } from 'modules/comments/sagas'
+import sagasManager from 'sagasManager'
+sagasManager.addSagaToRoot(sagas)

--- a/src/modules/index.js
+++ b/src/modules/index.js
@@ -1,7 +1,14 @@
 import { combineReducers } from 'redux-immutablejs'
 import tickets from 'modules/tickets'
+import teams from 'modules/teams'
+import comments from 'modules/comments'
+import projects from 'modules/projects'
+import users from 'modules/users'
 
 export default combineReducers({
   tickets,
+  teams,
+  comments,
+  projects,
+  users,
 })
-

--- a/src/modules/projects.js
+++ b/src/modules/projects.js
@@ -1,5 +1,8 @@
 export { default as actions } from 'modules/projects/actions'
 export { default as types } from 'modules/projects/types'
-export { default as sagas } from 'modules/projects/sagas'
 export * from 'modules/projects/selectors'
 export { default as default } from 'modules/projects/reducers'
+
+import { default as sagas } from 'modules/projects/sagas'
+import sagasManager from 'sagasManager'
+sagasManager.addSagaToRoot(sagas)

--- a/src/modules/teams.js
+++ b/src/modules/teams.js
@@ -1,5 +1,8 @@
 export { default as actions } from 'modules/teams/actions'
 export { default as types } from 'modules/teams/types'
-export { default as sagas } from 'modules/teams/sagas'
 export * from 'modules/teams/selectors'
 export { default as default } from 'modules/teams/reducers'
+
+import { default as sagas } from 'modules/teams/sagas'
+import sagasManager from 'sagasManager'
+sagasManager.addSagaToRoot(sagas)

--- a/src/modules/tickets.js
+++ b/src/modules/tickets.js
@@ -1,5 +1,8 @@
 export { default as actions } from 'modules/tickets/actions'
 export { default as types } from 'modules/tickets/types'
-export { default as sagas } from 'modules/tickets/sagas'
 export { default as selectors } from 'modules/tickets/selectors'
 export { default as default } from 'modules/tickets/reducers'
+
+import { default as sagas } from 'modules/tickets/sagas'
+import sagasManager from 'sagasManager'
+sagasManager.addSagaToRoot(sagas)

--- a/src/modules/users.js
+++ b/src/modules/users.js
@@ -1,5 +1,8 @@
 export { default as actions } from 'modules/users/actions'
 export { default as types } from 'modules/users/types'
-export { default as sagas } from 'modules/users/sagas'
 export * from 'modules/users/selectors'
 export { default as default } from 'modules/users/reducers'
+
+import { default as sagas } from 'modules/users/sagas'
+import sagasManager from 'sagasManager'
+sagasManager.addSagaToRoot(sagas)

--- a/src/sagas.js
+++ b/src/sagas.js
@@ -1,4 +1,0 @@
-import sagasManager from 'sagasManager'
-import { ticketSagas } from 'modules/tickets'
-
-sagasManager.addSagaToRoot(ticketSagas)

--- a/src/schema.js
+++ b/src/schema.js
@@ -10,7 +10,12 @@ export const ticket = new Schema('tickets', Ticket)
 
 const Project = new Record({
   id: null,
+  createdDate: null,
   name: null,
+  key: null,
+  homepage: null,
+  iconURL: null,
+  repo: null,
 })
 export const project = new Schema('projects', Project)
 

--- a/src/schema.js
+++ b/src/schema.js
@@ -25,7 +25,7 @@ export const team = new Schema('teams', Team)
 
 const Comment = new Record({
   id: null,
-  text: null,
+  body: null,
 })
 export const comment = new Schema('comments', Comment)
 

--- a/src/schema.js
+++ b/src/schema.js
@@ -21,10 +21,7 @@ export const project = new Schema('projects', Project)
 
 const Team = new Record({
   id: null,
-  createdAt: null,
-  icon: null,
   name: null,
-  urlSlug: null,
 })
 export const team = new Schema('teams', Team)
 

--- a/src/schema.js
+++ b/src/schema.js
@@ -3,6 +3,8 @@ import { Schema, arrayOf } from 'normalizr-immutable'
 
 const Ticket = new Record({
   id: null,
+  createdDate: null,
+  updatedDate: null,
   summary: null,
   description: null,
 })

--- a/test/modules/comments/actions_spec.js
+++ b/test/modules/comments/actions_spec.js
@@ -16,7 +16,7 @@ describe('comments module actions', () => {
     it('should return the correct type and the correct response', () => {
       const fixture = [{
         id: 1,
-        text: 'A Comment',
+        body: 'A Comment',
       }]
       const expectedResult = {
         type: types.FETCH_COMMENTS_SUCCESS,
@@ -51,7 +51,7 @@ describe('comments module actions', () => {
   describe('createCommentRequest', () => {
     const fixture = {
       id: 0,
-      text: 'A Comment',
+      body: 'A Comment',
     }
     const expectedResult = {
       type: types.CREATE_COMMENT_REQUEST,
@@ -70,7 +70,7 @@ describe('comments module actions', () => {
   describe('createCommentSuccess', () => {
     const fixture = {
       id: 0,
-      text: 'A Comment',
+      body: 'A Comment',
     }
     const expectedResult = {
       type: types.CREATE_COMMENT_SUCCESS,
@@ -116,7 +116,7 @@ describe('comments module actions', () => {
   describe('updateCommentRequest', () => {
     const fixture = {
       id: 0,
-      text: 'A Comment',
+      body: 'A Comment',
     }
     const expectedResult = {
       type: types.UPDATE_COMMENT_REQUEST,
@@ -136,7 +136,7 @@ describe('comments module actions', () => {
   describe('updateCommentSuccess', () => {
     const fixture = {
       id: 0,
-      text: 'A Comment',
+      body: 'A Comment',
     }
     const expectedResult = {
       type: types.UPDATE_COMMENT_SUCCESS,

--- a/test/modules/comments/reducer_spec.js
+++ b/test/modules/comments/reducer_spec.js
@@ -37,7 +37,7 @@ describe('comments module reducers', () => {
   describe('FETCH_COMMENTS_SUCCESS', () => {
     const fixture = [{
 			id: 1,
-			text: "A Comment",
+			body: "A Comment",
     }]
     const nextState = reducer(state, actions.fetchCommentsSuccess(fixture))
 
@@ -90,7 +90,7 @@ describe('comments module reducers', () => {
   describe('CREATE_COMMENT_SUCCESS', () => {
     const fixture = {
       id: 1,
-      text: "A Comment",
+      body: "A Comment",
     }
     const nextState = reducer(state, actions.createCommentSuccess(fixture))
 
@@ -144,7 +144,7 @@ describe('comments module reducers', () => {
   describe('UPDATE_COMMENT_SUCCESS', () => {
     const fixture = {
       id: 1,
-      text: 'A Comment'
+      body: 'A Comment'
     }
     const newState = state.merge(Map({
       ids: List.of(1),

--- a/test/modules/comments/selectors_spec.js
+++ b/test/modules/comments/selectors_spec.js
@@ -15,8 +15,7 @@ describe('comments selectors', () => {
         byId: {
           1: {
             id: 1,
-            summary: "This is a summary!",
-            description: "This is a description!"
+            body: 'This is a comment'
           }
         }
       }
@@ -24,8 +23,7 @@ describe('comments selectors', () => {
     const expected = fromJS([
       {
         id: 1,
-        summary: "This is a summary!",
-        description: "This is a description!"
+        body: 'This is a comment'
       }
     ])
 
@@ -39,16 +37,14 @@ describe('comments selectors', () => {
         byId: {
           1: {
             id: 1,
-            summary: "This is a summary!",
-            description: "This is a description!"
+            body: 'This is a comment'
           }
         }
       }
     })
     const expected = fromJS({
       id: 1,
-      summary: "This is a summary!",
-      description: "This is a description!"
+      body: 'This is a comment'
     })
 
     expect(commentSelector(state, 1)).to.deep.eq(expected)

--- a/test/modules/projects/actions_spec.js
+++ b/test/modules/projects/actions_spec.js
@@ -16,7 +16,12 @@ describe('projects module actions', () => {
     it('should return the correct type and the correct response', () => {
       const fixture = [{
         id: 1,
+        createdDate: '',
         name: 'A Project',
+        key: 'a-project',
+        homepage: '',
+        iconURL: '',
+        repo: '',
       }]
       const expectedResult = {
         type: types.FETCH_PROJECTS_SUCCESS,
@@ -50,11 +55,13 @@ describe('projects module actions', () => {
 
   describe('createProjectRequest', () => {
     const fixture = {
-      id: 0,
+      id: 1,
+      createdDate: '',
       name: 'A Project',
-      icon: "",
-      createdAt: "",
-      urlSlug: ""
+      key: 'a-project',
+      homepage: '',
+      iconURL: '',
+      repo: '',
     }
     const expectedResult = {
       type: types.CREATE_PROJECT_REQUEST,
@@ -72,16 +79,21 @@ describe('projects module actions', () => {
 
   describe('createProjectSuccess', () => {
     const fixture = {
-      id: 0,
+      id: 1,
+      createdDate: '',
       name: 'A Project',
+      key: 'a-project',
+      homepage: '',
+      iconURL: '',
+      repo: '',
     }
     const expectedResult = {
       type: types.CREATE_PROJECT_SUCCESS,
       response: {
-        result: 0,
+        result: 1,
         entities: {
           projects: {
-            0: fixture
+            1: fixture
           }
         }
       }
@@ -118,11 +130,13 @@ describe('projects module actions', () => {
 
   describe('updateProjectRequest', () => {
     const fixture = {
-      id: 0,
+      id: 1,
+      createdDate: '',
       name: 'A Project',
-      icon: "",
-      createdAt: "",
-      urlSlug: ""
+      key: 'a-project',
+      homepage: '',
+      iconURL: '',
+      repo: '',
     }
     const expectedResult = {
       type: types.UPDATE_PROJECT_REQUEST,
@@ -141,16 +155,21 @@ describe('projects module actions', () => {
 
   describe('updateProjectSuccess', () => {
     const fixture = {
-      id: 0,
+      id: 1,
+      createdDate: '',
       name: 'A Project',
+      key: 'a-project',
+      homepage: '',
+      iconURL: '',
+      repo: '',
     }
     const expectedResult = {
       type: types.UPDATE_PROJECT_SUCCESS,
       response: {
-        result: 0,
+        result: 1,
         entities: {
           projects: {
-            0: fixture
+            1: fixture
           }
         }
       }

--- a/test/modules/projects/reducer_spec.js
+++ b/test/modules/projects/reducer_spec.js
@@ -36,8 +36,13 @@ describe('projects module reducers', () => {
 
   describe('FETCH_PROJECTS_SUCCESS', () => {
     const fixture = [{
-			id: 1,
-			name: "The A Project",
+      id: 1,
+      createdDate: '',
+      name: 'A Project',
+      key: 'a-project',
+      homepage: '',
+      iconURL: '',
+      repo: '',
     }]
     const nextState = reducer(state, actions.fetchProjectsSuccess(fixture))
 
@@ -90,7 +95,12 @@ describe('projects module reducers', () => {
   describe('CREATE_PROJECT_SUCCESS', () => {
     const fixture = {
       id: 1,
-      name: "The A Project",
+      createdDate: '',
+      name: 'A Project',
+      key: 'a-project',
+      homepage: '',
+      iconURL: '',
+      repo: '',
     }
     const nextState = reducer(state, actions.createProjectSuccess(fixture))
 
@@ -144,7 +154,12 @@ describe('projects module reducers', () => {
   describe('UPDATE_PROJECT_SUCCESS', () => {
     const fixture = {
       id: 1,
-      name: 'The A Project'
+      createdDate: '',
+      name: 'A Project',
+      key: 'a-project',
+      homepage: '',
+      iconURL: '',
+      repo: '',
     }
     const newState = state.merge(Map({
       ids: List.of(1),

--- a/test/modules/teams/actions_spec.js
+++ b/test/modules/teams/actions_spec.js
@@ -17,9 +17,6 @@ describe('teams module actions', () => {
       const fixture = [{
         id: 1,
         name: 'A Team',
-        icon: "",
-        createdAt: "",
-        urlSlug: ""
       }]
       const expectedResult = {
         type: types.FETCH_TEAMS_SUCCESS,
@@ -55,9 +52,6 @@ describe('teams module actions', () => {
     const fixture = {
       id: 0,
       name: 'A Team',
-      icon: "",
-      createdAt: "",
-      urlSlug: ""
     }
     const expectedResult = {
       type: types.CREATE_TEAM_REQUEST,
@@ -77,9 +71,6 @@ describe('teams module actions', () => {
     const fixture = {
       id: 0,
       name: 'A Team',
-      icon: "",
-      createdAt: "",
-      urlSlug: ""
     }
     const expectedResult = {
       type: types.CREATE_TEAM_SUCCESS,
@@ -126,9 +117,6 @@ describe('teams module actions', () => {
     const fixture = {
       id: 0,
       name: 'A Team',
-      icon: "",
-      createdAt: "",
-      urlSlug: ""
     }
     const expectedResult = {
       type: types.UPDATE_TEAM_REQUEST,
@@ -149,9 +137,6 @@ describe('teams module actions', () => {
     const fixture = {
       id: 0,
       name: 'A Team',
-      icon: "",
-      createdAt: "",
-      urlSlug: ""
     }
     const expectedResult = {
       type: types.UPDATE_TEAM_SUCCESS,

--- a/test/modules/teams/reducer_spec.js
+++ b/test/modules/teams/reducer_spec.js
@@ -37,10 +37,7 @@ describe('teams module reducers', () => {
   describe('FETCH_TEAMS_SUCCESS', () => {
     const fixture = [{
 			id: 1,
-			createdAt: "Wed, 28 Sep 2016 01:17:30 GMT",
-			icon: "",
 			name: "The A Team",
-			urlSlug: "the-a-team"
     }]
     const nextState = reducer(state, actions.fetchTeamsSuccess(fixture))
 
@@ -93,10 +90,7 @@ describe('teams module reducers', () => {
   describe('CREATE_TEAM_SUCCESS', () => {
     const fixture = {
       id: 1,
-      createdAt: "Wed, 28 Sep 2016 01:17:30 GMT",
-      icon: "",
       name: "The A Team",
-      urlSlug: "the-a-team"
     }
     const nextState = reducer(state, actions.createTeamSuccess(fixture))
 
@@ -150,19 +144,13 @@ describe('teams module reducers', () => {
   describe('UPDATE_TEAM_SUCCESS', () => {
     const fixture = {
       id: 1,
-      createdAt: "Wed, 28 Sep 2016 01:17:30 GMT",
-      icon: "",
       name: "The A Team",
-      urlSlug: "the-a-team"
     }
     const newState = state.merge(Map({
       ids: List.of(1),
       byId: Map({ 1: Map({
         id: 1,
-        createdAt: "Wed, 28 Sep 2016 01:17:30 GMT",
-        icon: "",
         name: "The B Team",
-        urlSlug: "the-b-team"
       }) })
     }))
     const nextState = reducer(newState, actions.updateTeamSuccess(fixture))

--- a/test/modules/tickets/actions_spec.js
+++ b/test/modules/tickets/actions_spec.js
@@ -16,6 +16,8 @@ describe('tickets module actions', () => {
     it('should return the correct type and the correct response', () => {
       const fixture = [{
         id: 1,
+        createdDate: '',
+        updatedDate: '',
         description: 'Ticket description',
         summary: 'Ticket summary',
       }]
@@ -71,6 +73,8 @@ describe('tickets module actions', () => {
   describe('createTicketSuccess', () => {
     const fixture = {
       id: 1,
+      createdDate: '',
+      updatedDate: '',
       description: "This is a cool ticket",
       summary: "This is a ticket summary"
     }
@@ -116,6 +120,8 @@ describe('tickets module actions', () => {
   describe('updateTicketRequest', () => {
     const fixture = {
       id: 0,
+      createdDate: '',
+      updatedDate: '',
       summary: 'Ticket summary',
       description: 'Ticket description'
     }
@@ -136,6 +142,8 @@ describe('tickets module actions', () => {
   describe('updateTicketSuccess', () => {
     const fixture = {
       id: 1,
+      createdDate: '',
+      updatedDate: '',
       description: "This is a cool ticket",
       summary: "This is a ticket summary"
     }

--- a/test/modules/tickets/reducer_spec.js
+++ b/test/modules/tickets/reducer_spec.js
@@ -37,6 +37,8 @@ describe('tickets module reducers', () => {
   describe('FETCH_TICKETS_SUCCESS', () => {
     const fixture = [{
       id: 0,
+      createdDate: '',
+      updatedDate: '',
       summary: 'Ticket summary',
       description: 'Ticket description'
     }]
@@ -92,6 +94,8 @@ describe('tickets module reducers', () => {
   describe('CREATE_TICKET_SUCCESS', () => {
     const fixture = {
       id: 0,
+      createdDate: '',
+      updatedDate: '',
       summary: 'Ticket summary',
       description: 'Ticket description'
     }
@@ -149,6 +153,8 @@ describe('tickets module reducers', () => {
   describe('UPDATE_TICKET_SUCCESS', () => {
     const fixture = {
       id: 1,
+      createdDate: '',
+      updatedDate: '',
       summary: 'Ticket summary',
       description: 'Ticket description'
     }


### PR DESCRIPTION
Updated schemas for major models to reflect the simple-type fields (string, int, etc.) listed in backend `models.go` file. Complex fields (TicketType, TicketStatus, etc.) were not added because they do not exist, and relationships between models were not added because redux needs to be re-worked to allow for that. 