### PR TITLE
Eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,7 +7,10 @@ module.exports = {
 
   parser: 'babel-eslint',
 
-  extends: 'airbnb',
+  extends: [
+    'airbnb',
+    'plugin:import/errors'
+  ],
 
   parserOptions: {
     ecmaVersion: 6,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -54,6 +54,7 @@ module.exports = {
     'react/jsx-filename-extension': 0,
     'react/forbid-prop-types': 1,
     'react/require-default-props': 2,
+    'react/no-array-index-key': 2,
 
     'jsx-a11y/href-no-hash': 0,
   }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -52,6 +52,7 @@ module.exports = {
     'import/prefer-default-export': 0,
 
     'react/jsx-filename-extension': 0,
+    'react/forbid-prop-types': 1,
 
     'jsx-a11y/href-no-hash': 0,
   }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -53,6 +53,7 @@ module.exports = {
 
     'react/jsx-filename-extension': 0,
     'react/forbid-prop-types': 1,
+    'react/require-default-props': 2,
 
     'jsx-a11y/href-no-hash': 0,
   }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,7 +35,7 @@ module.exports = {
   },
 
   rules: {
-    semi: 0,
+    semi: ['error', 'never'],
     'jsx-quotes': 0,
     'no-undef': 0,
     'arrow-body-style': 0,
@@ -52,8 +52,6 @@ module.exports = {
     'import/prefer-default-export': 0,
 
     'react/jsx-filename-extension': 0,
-    'react/forbid-prop-types': 0,
-    'react/prop-types': 0,
 
     'jsx-a11y/href-no-hash': 0,
   }

--- a/mochacfg.js
+++ b/mochacfg.js
@@ -1,1 +1,1 @@
-require.extensions['.png'] = function mochaPngConfig() { return null; }
+require.extensions['.png'] = function mochaPngConfig() { return null }

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -10,7 +10,11 @@ const App = ({ children }) => (
 )
 
 App.propTypes = {
-  children: PropTypes.any,
+  children: PropTypes.node,
+}
+
+App.defaultProps = {
+  children: [],
 }
 
 export default App

--- a/src/components/Root.js
+++ b/src/components/Root.js
@@ -13,6 +13,7 @@ const Root = ({ store, history }) => (
 
 Root.propTypes = {
   store: PropTypes.object.isRequired,
+  history: PropTypes.object.isRequired,
 }
 
 export default Root

--- a/src/components/auth/UserInfoBox/index.js
+++ b/src/components/auth/UserInfoBox/index.js
@@ -21,6 +21,11 @@ UserInfoBox.propTypes = {
   user: React.PropTypes.object,
 }
 
+UserInfoBox.defaultProps = {
+  loggedIn: false,
+  user: {},
+}
+
 export { UserInfoBox }
 
 const stateToProps = state => ({

--- a/src/components/misc/Button/index.js
+++ b/src/components/misc/Button/index.js
@@ -9,11 +9,6 @@ const Button = ({ children, ...rest }) => (
 
 Button.propTypes = {
   children: React.PropTypes.node.isRequired,
-  rest: React.PropTypes.object,
-}
-
-Button.defaultProps = {
-  rest: {},
 }
 
 export default Button

--- a/src/components/misc/Button/index.js
+++ b/src/components/misc/Button/index.js
@@ -1,10 +1,19 @@
 import React from 'react'
 import { Button as ButtonReactstrap } from 'reactstrap'
 
-const Button = props => (
-  <ButtonReactstrap {...props}>
-    {props.children}
+const Button = ({ children, ...rest }) => (
+  <ButtonReactstrap {...rest}>
+    {children}
   </ButtonReactstrap>
 )
+
+Button.propTypes = {
+  children: React.PropTypes.node.isRequired,
+  rest: React.PropTypes.object,
+}
+
+Button.defaultProps = {
+  rest: {},
+}
 
 export default Button

--- a/src/components/misc/Flash/index.js
+++ b/src/components/misc/Flash/index.js
@@ -1,11 +1,6 @@
 import React from 'react'
 
 const Flash = ({ message }) => {
-  if (message == null || message.length === 0 ||
-     (typeof message === 'object' && message.data == null)) {
-    return (<div />)
-  }
-
   if (typeof message === 'object') {
     return (
       <div className="flash-message">
@@ -25,7 +20,7 @@ Flash.propTypes = {
   message: React.PropTypes.oneOfType([
     React.PropTypes.string,
     React.PropTypes.object,
-  ])
+  ]).isRequired,
 }
 
 export default Flash

--- a/src/components/misc/LinkButton/index.js
+++ b/src/components/misc/LinkButton/index.js
@@ -13,11 +13,6 @@ const LinkButton = ({ to, children, ...rest }) => (
 LinkButton.propTypes = {
   to: React.PropTypes.string.isRequired,
   children: React.PropTypes.node.isRequired,
-  rest: React.PropTypes.any,
-}
-
-LinkButton.defaultProps = {
-  rest: {},
 }
 
 export default LinkButton

--- a/src/components/misc/LinkButton/index.js
+++ b/src/components/misc/LinkButton/index.js
@@ -2,12 +2,22 @@ import React from 'react'
 import { Link } from 'react-router'
 import { Button } from 'components'
 
-const LinkButton = props => (
-  <Link to={props.to}>
-    <Button {...props} >
-      {props.children}
+const LinkButton = ({ to, children, ...rest }) => (
+  <Link to={to}>
+    <Button {...rest} >
+      {children}
     </Button>
   </Link>
 )
+
+LinkButton.propTypes = {
+  to: React.PropTypes.string.isRequired,
+  children: React.PropTypes.node.isRequired,
+  rest: React.PropTypes.any,
+}
+
+LinkButton.defaultProps = {
+  rest: {},
+}
 
 export default LinkButton

--- a/src/components/projects/ProjectCard/index.js
+++ b/src/components/projects/ProjectCard/index.js
@@ -43,4 +43,10 @@ ProjectCard.propTypes = {
   loading: React.PropTypes.bool,
 }
 
+ProjectCard.defaultProps = {
+  error: null,
+  project: null,
+  loading: false,
+}
+
 export default ProjectCard

--- a/src/components/projects/ProjectEdit/index.js
+++ b/src/components/projects/ProjectEdit/index.js
@@ -12,6 +12,10 @@ export class ProjectEdit extends Component {
     initialValues: React.PropTypes.object,
   }
 
+  static defaultProps = {
+    initialValues: {},
+  }
+
   componentWillMount() {
     this.props.loadProject(this.props.params.key)
   }

--- a/src/components/projects/ProjectLink/index.js
+++ b/src/components/projects/ProjectLink/index.js
@@ -12,4 +12,8 @@ ProjectLink.propTypes = {
   children: React.PropTypes.node,
 }
 
+ProjectLink.defaultProps = {
+  children: [],
+}
+
 export default ProjectLink

--- a/src/components/projects/ProjectList/index.js
+++ b/src/components/projects/ProjectList/index.js
@@ -18,8 +18,8 @@ export const ProjectTable = ({ projects: projectList }) => (
         </tr>
       </thead>
       <tbody>
-        {projectList.map((project, i) =>
-          <tr key={i}>
+        {projectList.map(project =>
+          <tr key={project.id}>
             <td>
               <ProjectLink project={project}>{project.name}</ProjectLink>
             </td>

--- a/src/components/projects/ProjectShow/index.js
+++ b/src/components/projects/ProjectShow/index.js
@@ -8,7 +8,7 @@ export class ProjectShow extends Component {
   static propTypes = {
     params: React.PropTypes.object.isRequired,
     loadProject: React.PropTypes.func.isRequired,
-    project: React.PropTypes.object,
+    project: React.PropTypes.object.isRequired,
   }
 
   componentWillMount() {

--- a/src/components/teams/TeamCard/index.js
+++ b/src/components/teams/TeamCard/index.js
@@ -22,8 +22,8 @@ const TeamCard = ({ team, loading, error }) => {
                 Lead: <UserLink user={team.lead}>{team.lead.username}</UserLink>
               </CardText>
             }
-            {team.members && team.members.map((member, i) =>
-              <CardText key={i}>
+            {team.members && team.members.map(member =>
+              <CardText key={member.id}>
                 Member: <UserLink user={member}>{member.username}</UserLink>
               </CardText>
             )}
@@ -44,6 +44,12 @@ TeamCard.propTypes = {
   team: React.PropTypes.object,
   loading: React.PropTypes.bool,
   error: React.PropTypes.string,
+}
+
+TeamCard.defaultProps = {
+  team: null,
+  loading: false,
+  error: null,
 }
 
 export default TeamCard

--- a/src/components/teams/TeamEdit/index.js
+++ b/src/components/teams/TeamEdit/index.js
@@ -12,6 +12,10 @@ export class TeamEdit extends Component {
     initialValues: React.PropTypes.object,
   }
 
+  static defaultProps = {
+    initialValues: {},
+  }
+
   componentWillMount() {
     this.props.loadTeam(this.props.params.name)
   }

--- a/src/components/teams/TeamLink/index.js
+++ b/src/components/teams/TeamLink/index.js
@@ -12,4 +12,8 @@ TeamLink.propTypes = {
   children: React.PropTypes.node,
 }
 
+TeamLink.defaultProps = {
+  children: [],
+}
+
 export default TeamLink

--- a/src/components/teams/TeamList/index.js
+++ b/src/components/teams/TeamList/index.js
@@ -16,8 +16,8 @@ export const TeamTable = ({ teams: teamList }) => (
         </tr>
       </thead>
       <tbody>
-        {teamList.map((team, i) =>
-          <tr key={i}>
+        {teamList.map(team =>
+          <tr key={team.id}>
             <td>
               <TeamLink team={team}>{team.name}</TeamLink>
             </td>
@@ -29,8 +29,8 @@ export const TeamTable = ({ teams: teamList }) => (
             <td>
               {team.members &&
                 <ul>
-                  {team.members.map((member, j) =>
-                    <li key={j}>
+                  {team.members.map(member =>
+                    <li key={member.id}>
                       <UserLink user={member}>{member.username}</UserLink>
                     </li>
                   )}
@@ -51,7 +51,7 @@ TeamTable.propTypes = {
 class TeamList extends Component {
   static propTypes = {
     loadTeams: React.PropTypes.func.isRequired,
-    teams: React.PropTypes.array,
+    teams: React.PropTypes.array.isRequired,
   }
 
   componentWillMount() {

--- a/src/components/teams/TeamShow/index.js
+++ b/src/components/teams/TeamShow/index.js
@@ -8,7 +8,7 @@ export class TeamShow extends Component {
   static propTypes = {
     params: React.PropTypes.object.isRequired,
     loadTeam: React.PropTypes.func.isRequired,
-    team: React.PropTypes.object,
+    team: React.PropTypes.object.isRequired,
   }
 
   componentWillMount() {

--- a/src/components/tickets/TicketCard/index.js
+++ b/src/components/tickets/TicketCard/index.js
@@ -48,4 +48,10 @@ Ticket.propTypes = {
   loading: React.PropTypes.bool,
 }
 
+Ticket.defaultProps = {
+  ticket: null,
+  error: null,
+  loading: false,
+}
+
 export default Ticket

--- a/src/components/tickets/TicketDeleteButton/index.js
+++ b/src/components/tickets/TicketDeleteButton/index.js
@@ -8,7 +8,7 @@ const TicketDeleteButton = ({ ticket, deleteTicket }) => (
 )
 
 TicketDeleteButton.propTypes = {
-  ticket: React.PropTypes.object,
+  ticket: React.PropTypes.object.isRequired,
   deleteTicket: React.PropTypes.func.isRequired,
 }
 

--- a/src/components/tickets/TicketEdit/index.js
+++ b/src/components/tickets/TicketEdit/index.js
@@ -12,6 +12,10 @@ export class TicketEdit extends Component {
     initialValues: React.PropTypes.object,
   }
 
+  static defaultProps = {
+    initialValues: {},
+  }
+
   componentWillMount() {
     this.props.loadTicket(this.props.params.key)
   }

--- a/src/components/tickets/TicketLink/index.js
+++ b/src/components/tickets/TicketLink/index.js
@@ -12,4 +12,8 @@ TicketLink.propTypes = {
   children: React.PropTypes.node,
 }
 
+TicketLink.defaultProps = {
+  children: [],
+}
+
 export default TicketLink

--- a/src/components/tickets/TicketList/index.js
+++ b/src/components/tickets/TicketList/index.js
@@ -20,8 +20,8 @@ export const TicketTable = ({ tickets: ticketList }) => (
         </tr>
       </thead>
       <tbody>
-        {ticketList.map((ticket, i) =>
-          <tr key={i}>
+        {ticketList.map(ticket =>
+          <tr key={ticket.id}>
             <td>{ticket.id}</td>
             <td>
               <TicketLink ticket={ticket}>{ticket.key}</TicketLink>
@@ -52,7 +52,7 @@ TicketTable.propTypes = {
 export class TicketList extends Component {
   static propTypes = {
     loadTickets: React.PropTypes.func.isRequired,
-    tickets: React.PropTypes.array,
+    tickets: React.PropTypes.array.isRequired,
   }
 
   componentWillMount() {

--- a/src/components/tickets/TicketShow/index.js
+++ b/src/components/tickets/TicketShow/index.js
@@ -8,7 +8,7 @@ export class TicketShow extends Component {
   static propTypes = {
     params: React.PropTypes.object.isRequired,
     loadTicket: React.PropTypes.func.isRequired,
-    ticket: React.PropTypes.object,
+    ticket: React.PropTypes.object.isRequired,
   }
 
   componentWillMount() {

--- a/src/components/users/UserCard/index.js
+++ b/src/components/users/UserCard/index.js
@@ -37,4 +37,10 @@ UserCard.propTypes = {
   error: React.PropTypes.string,
 }
 
+UserCard.defaultProps = {
+  user: null,
+  loading: false,
+  error: null,
+}
+
 export default UserCard

--- a/src/components/users/UserLink/index.js
+++ b/src/components/users/UserLink/index.js
@@ -12,4 +12,8 @@ UserLink.propTypes = {
   children: React.PropTypes.node,
 }
 
+UserLink.defaultProps = {
+  children: [],
+}
+
 export default UserLink

--- a/src/components/users/UserList/index.js
+++ b/src/components/users/UserList/index.js
@@ -17,8 +17,8 @@ export const UserTable = ({ users: userList }) => {
           </tr>
         </thead>
         <tbody>
-          {userList.map((user, i) =>
-            <tr key={i}>
+          {userList.map(user =>
+            <tr key={user.id}>
               <td>
                 <Gravatar
                   email={user.email}
@@ -45,6 +45,10 @@ export class UserList extends Component {
   static propTypes = {
     loadUsers: React.PropTypes.func.isRequired,
     users: React.PropTypes.array,
+  }
+
+  static defaultProps = {
+    users: [],
   }
 
   componentWillMount() {

--- a/src/components/users/UserShow/index.js
+++ b/src/components/users/UserShow/index.js
@@ -5,11 +5,15 @@ import actions, { user, fetching } from 'modules/user'
 import { UserCard } from 'components/users'
 
 export class UserShow extends Component {
+  static defaultProps = {
+    loading: false,
+  }
+
   static propTypes = {
     params: React.PropTypes.object.isRequired,
     loadUser: React.PropTypes.func.isRequired,
     loading: React.PropTypes.bool,
-    user: React.PropTypes.object,
+    user: React.PropTypes.object.isRequired,
   }
 
   componentWillMount() {

--- a/src/modules/auth.js
+++ b/src/modules/auth.js
@@ -11,7 +11,7 @@ const { Types: types, Creators: creators } = createActions({
   registerRequest: ['payload'],
   registerSuccess: ['payload'],
   registerFailure: ['error'],
-}, { prefix: 'AUTH_' });
+}, { prefix: 'AUTH_' })
 
 export const authTypes = types
 export default creators

--- a/src/modules/comment.js
+++ b/src/modules/comment.js
@@ -18,7 +18,7 @@ const { Types: types, Creators: creators } = createActions({
   deleteRequest: ['id'],
   deleteSuccess: ['id'],
   deleteFailure: ['error'],
-}, { prefix: 'COMMENT_' });
+}, { prefix: 'COMMENT_' })
 
 export const commentTypes = types
 export default creators

--- a/src/modules/project.js
+++ b/src/modules/project.js
@@ -18,7 +18,7 @@ const { Types: types, Creators: creators } = createActions({
   deleteRequest: ['key'],
   deleteSuccess: ['key'],
   deleteFailure: ['error'],
-}, { prefix: 'PROJECT_' });
+}, { prefix: 'PROJECT_' })
 
 export const projectTypes = types
 export default creators

--- a/src/modules/team.js
+++ b/src/modules/team.js
@@ -18,7 +18,7 @@ const { Types: types, Creators: creators } = createActions({
   deleteRequest: ['name'],
   deleteSuccess: ['name'],
   deleteFailure: ['error'],
-}, { prefix: 'TEAM_' });
+}, { prefix: 'TEAM_' })
 
 export const teamTypes = types
 export default creators

--- a/src/modules/ticket.js
+++ b/src/modules/ticket.js
@@ -18,7 +18,7 @@ const { Types: types, Creators: creators } = createActions({
   deleteRequest: ['key'],
   deleteSuccess: ['key'],
   deleteFailure: ['error'],
-}, { prefix: 'TICKET_' });
+}, { prefix: 'TICKET_' })
 
 export const ticketTypes = types
 export default creators

--- a/src/modules/user.js
+++ b/src/modules/user.js
@@ -18,7 +18,7 @@ const { Types: types, Creators: creators } = createActions({
   deleteRequest: ['username'],
   deleteSuccess: ['username'],
   deleteFailure: ['error'],
-}, { prefix: 'USER_' });
+}, { prefix: 'USER_' })
 
 export const userTypes = types
 export default creators

--- a/src/utils/render-field.js
+++ b/src/utils/render-field.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { FormGroup, Label, Input, FormText } from 'components/forms'
 
-export default ({ input, label, type, meta: { touched, error, warning } }) => {
+export const RenderField = ({ input, label, type, meta: { touched, error, warning } }) => {
   let state
 
   if (warning) {
@@ -18,4 +18,15 @@ export default ({ input, label, type, meta: { touched, error, warning } }) => {
       {touched && (error || warning) && <FormText>{error || warning}</FormText>}
     </FormGroup>
   )
+}
+
+RenderField.propTypes = {
+  input: React.PropTypes.object.isRequired,
+  label: React.PropTypes.string.isRequired,
+  type: React.PropTypes.string.isRequired,
+  meta: React.PropTypes.shape({
+    touched: React.PropTypes.bool,
+    error: React.PropTypes.string,
+    warning: React.PropTypes.string,
+  }).isRequired
 }

--- a/src/utils/render-field.js
+++ b/src/utils/render-field.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { FormGroup, Label, Input, FormText } from 'components/forms'
 
-export const RenderField = ({ input, label, type, meta: { touched, error, warning } }) => {
+const renderField = ({ input, label, type, meta: { touched, error, warning } }) => {
   let state
 
   if (warning) {
@@ -20,7 +20,7 @@ export const RenderField = ({ input, label, type, meta: { touched, error, warnin
   )
 }
 
-RenderField.propTypes = {
+renderField.propTypes = {
   input: React.PropTypes.object.isRequired,
   label: React.PropTypes.string.isRequired,
   type: React.PropTypes.string.isRequired,
@@ -30,3 +30,5 @@ RenderField.propTypes = {
     warning: React.PropTypes.string,
   }).isRequired
 }
+
+export default renderField

--- a/test/components/Button.spec.js
+++ b/test/components/Button.spec.js
@@ -5,7 +5,7 @@ import { Button } from 'components'
 
 describe('Button Component', () => {
   it('renders', () => {
-    const wrapper = shallow(<Button />)
+    const wrapper = shallow(<Button children={[]} />)
 
     expect(wrapper.exists()).to.be.true
   })

--- a/test/components/DeleteButton.spec.js
+++ b/test/components/DeleteButton.spec.js
@@ -6,7 +6,7 @@ import { DeleteButton } from 'components'
 
 describe('DeleteButton Component', () => {
   it('renders', () => {
-    const wrapper = shallow(<DeleteButton />)
+    const wrapper = shallow(<DeleteButton handleClick={() => {}} />)
 
     expect(wrapper.exists()).to.be.true
   })

--- a/test/components/Flash.spec.js
+++ b/test/components/Flash.spec.js
@@ -21,10 +21,4 @@ describe('Flash Component', () => {
 
     expect(wrapper).to.contain.text('Message')
   })
-
-  it('renders an empty div if no message', () => {
-    const wrapper = shallow(<Flash />)
-
-    expect(wrapper.text().length).to.eq(0)
-  })
 })

--- a/test/components/LinkButton.spec.js
+++ b/test/components/LinkButton.spec.js
@@ -7,7 +7,8 @@ import { Link } from 'react-router'
 describe('LinkButton Component', () => {
   const setup = propOverrides => {
     const props = Object.assign({
-      children: null,
+      children: [],
+      to: '',
     }, propOverrides)
 
     const wrapper = shallow(<LinkButton {...props} />)

--- a/test/components/ProjectList.spec.js
+++ b/test/components/ProjectList.spec.js
@@ -12,6 +12,7 @@ describe('ProjectList Component', () => {
         keys: ['PROJECT-TEST'],
         byKey: {
           'PROJECT-TEST': {
+            id: 0,
             key: 'PROJECT-TEST'
           }
         }
@@ -52,9 +53,9 @@ describe('ProjectList Component', () => {
 
   it('passes projects to table component', () => {
     const projects = [
-      { key: 'PROJECT-1' },
-      { key: 'PROJECT-2' },
-      { key: 'PROJECT-3' },
+      { key: 'PROJECT-1', id: 0 },
+      { key: 'PROJECT-2', id: 1 },
+      { key: 'PROJECT-3', id: 2 },
     ]
     const { wrapper } = setup({ projects })
     const table = wrapper.find(ProjectTable)

--- a/test/components/ProjectShow.spec.js
+++ b/test/components/ProjectShow.spec.js
@@ -13,6 +13,7 @@ describe('ProjectShow Component', () => {
           keys: ['PROJECT-TEST'],
           byKey: {
             'PROJECT-TEST': {
+              id: 0,
               key: 'PROJECT-TEST'
             }
           }
@@ -39,13 +40,13 @@ describe('ProjectShow Component', () => {
 
   it('calls load project action on mount', () => {
     const callback = sinon.spy()
-    const wrapper = shallow(<ProjectShow loadProject={callback} params={{ key: 'PROJECT-1' }} />)
+    const wrapper = shallow(<ProjectShow loadProject={callback} project={{ id: 0 }} params={{ key: 'PROJECT-1' }} />)
     expect(callback.calledOnce).to.be.true
   })
 
   it('calls load project action on update', () => {
     const callback = sinon.spy()
-    const wrapper = shallow(<ProjectShow loadProject={callback} params={{ key: 'PROJECT-1' }} />)
+    const wrapper = shallow(<ProjectShow loadProject={callback} project={{ id: 0 }} params={{ key: 'PROJECT-1' }} />)
     callback.reset()
     wrapper.instance().componentDidUpdate({ params: { key: 'PROJECT-2' } })
     expect(callback.calledOnce).to.be.true

--- a/test/components/ProjectTable.spec.js
+++ b/test/components/ProjectTable.spec.js
@@ -22,9 +22,11 @@ describe('ProjectTable', () => {
   }
 
   const fixture = {
+    id: 0,
     name: 'Project 1',
     key: 'PROJECT-1',
     lead: {
+      id: 0,
       username: 'user0',
       fullName: 'User 0',
     },

--- a/test/components/TeamCard.spec.js
+++ b/test/components/TeamCard.spec.js
@@ -70,19 +70,21 @@ describe('TeamCard Component', () => {
     })
 
     it('renders team lead link', () => {
-      const team = { name: 'team', lead: { username: 'user0' } }
+      const user = { username: 'user0', id: 0 }
+      const team = { name: 'team', lead: user }
       const { userLink } = setup({ team })
 
-      expect(userLink.prop('user')).to.deep.eq({ username: 'user0' })
+      expect(userLink.prop('user')).to.deep.eq(user)
       expect(userLink.prop('children')).to.eq('user0')
     })
 
     it('renders team member links', () => {
-      const team = { name: 'team', members: [{ username: 'user0' }] }
+      const user = { username: 'user0', id: 0 }
+      const team = { name: 'team', members: [user] }
 
       const { userLink } = setup({ team })
 
-      expect(userLink.prop('user')).to.deep.eq({ username: 'user0' })
+      expect(userLink.prop('user')).to.deep.eq(user)
       expect(userLink.prop('children')).to.eq('user0')
     })
 

--- a/test/components/TeamList.spec.js
+++ b/test/components/TeamList.spec.js
@@ -12,6 +12,7 @@ describe('TeamList Component', () => {
         names: ['TEAM-TEST'],
         byName: {
           'TEAM-TEST': {
+            id: 0,
             name: 'TEST-TEST',
           }
         }
@@ -53,9 +54,9 @@ describe('TeamList Component', () => {
 
   it('passes teams to table component', () => {
     const teams = [
-      { name: 'TEAM-1' },
-      { name: 'TEAM-2' },
-      { name: 'TEAM-3' },
+      { name: 'TEAM-1', id: 0 },
+      { name: 'TEAM-2', id: 1 },
+      { name: 'TEAM-3', id: 2 },
     ]
     const { wrapper } = setup({ teams })
     const table = wrapper.find(TeamTable)

--- a/test/components/TeamShow.spec.js
+++ b/test/components/TeamShow.spec.js
@@ -37,13 +37,13 @@ describe('TeamShow Component', () => {
 
   it('calls load team action on mount', () => {
     const callback = sinon.spy()
-    const wrapper = shallow(<TeamShow loadTeam={callback} params={{ name: 'TEAM-1' }} />)
+    const wrapper = shallow(<TeamShow loadTeam={callback} team={{}} params={{ name: 'TEAM-1' }} />)
     expect(callback.calledOnce).to.be.true
   })
 
   it('calls load team action on update', () => {
     const callback = sinon.spy()
-    const wrapper = shallow(<TeamShow loadTeam={callback} params={{name: 'TEAM-2'}} />)
+    const wrapper = shallow(<TeamShow loadTeam={callback} team={{}} params={{name: 'TEAM-2'}} />)
     callback.reset()
     wrapper.instance().componentDidUpdate({ params: { name: 'TEAM-1' } })
     expect(callback.calledOnce).to.be.true

--- a/test/components/TeamTable.spec.js
+++ b/test/components/TeamTable.spec.js
@@ -23,20 +23,24 @@ describe('TeamTable Component', () => {
 
   const fixtures = [
     {
+      id: 0,
       name: 'Team With Lead',
       lead: {
         username: 'user0',
+        id: 0,
       },
     },
     {
+      id: 1,
       name: 'Team With Members',
       members: [
-        { username: 'user0' },
-        { username: 'user1' },
-        { username: 'user2' },
+        { username: 'user0', id: 0 },
+        { username: 'user1', id: 1 },
+        { username: 'user2', id: 2 },
       ],
     },
     {
+      id: 2,
       name: 'Team With None'
     }
   ]

--- a/test/components/TicketDeleteButton.spec.js
+++ b/test/components/TicketDeleteButton.spec.js
@@ -9,7 +9,7 @@ import { DeleteButton } from 'components'
 describe('TicketDeleteButton Component', () => {
   it('renders', () => {
     const Enhanced = wrapProvider()(Container)
-    const wrapper = mount(<Enhanced />)
+    const wrapper = mount(<Enhanced ticket={{}} />)
 
     const container = wrapper.find(Container)
     const component = wrapper.find(TicketDeleteButton)

--- a/test/components/TicketList.spec.js
+++ b/test/components/TicketList.spec.js
@@ -12,6 +12,7 @@ describe('TicketList Component', () => {
         keys: ['TICKET-TEST'],
         byKey: {
           'TICKET-TEST': {
+            id: 0,
             key: 'TICKET-TEST'
           }
         }

--- a/test/components/TicketShow.spec.js
+++ b/test/components/TicketShow.spec.js
@@ -37,13 +37,13 @@ describe('TicketShow Component', () => {
 
   it('calls load ticket action on mount', () => {
     const callback = sinon.spy()
-    const wrapper = shallow(<TicketShow loadTicket={callback} params={{ key: 'TICKET-1' }} />)
+    const wrapper = shallow(<TicketShow loadTicket={callback} ticket={{}} params={{ key: 'TICKET-1' }} />)
     expect(callback.calledOnce)
   })
 
   it('calls load ticket action on update', () => {
     const callback = sinon.spy()
-    const wrapper = shallow(<TicketShow loadTicket={callback} params={{ key: 'TICKET-1' }} />)
+    const wrapper = shallow(<TicketShow loadTicket={callback} ticket={{}} params={{ key: 'TICKET-1' }} />)
     callback.reset()
     wrapper.instance().componentDidUpdate({ params: { key: 'TICKET-2' } })
     expect(callback.calledOnce).to.be.true

--- a/test/components/TicketTable.spec.js
+++ b/test/components/TicketTable.spec.js
@@ -28,9 +28,11 @@ describe('TicketTable Component', () => {
       summary: 'Ticket Summary',
       description: 'Ticket Description',
       reporter: {
+        id: 0,
         username: 'user0',
       },
       assignee: {
+        id: 1,
         username: 'user1',
       },
     }
@@ -58,7 +60,7 @@ describe('TicketTable Component', () => {
   })
 
   it('does not render reporter and assignee links if not provided', () => {
-    const { userLink } = setup({ tickets: [{}] })
+    const { userLink } = setup({ tickets: [{ id: 0 }] })
 
     expect(userLink.exists()).to.be.false
   })

--- a/test/components/UserList.spec.js
+++ b/test/components/UserList.spec.js
@@ -12,6 +12,7 @@ describe('UserList Component', () => {
         usernames: ['USER1'],
         byUsername: {
           'USER1': {
+            id: 1,
             username: 'USER1',
             email: 'user1@users.com',
           }

--- a/test/components/UserShow.spec.js
+++ b/test/components/UserShow.spec.js
@@ -38,7 +38,7 @@ describe('UserShow Component', () => {
 
   it('calls load user action on mount', () => {
     const callback = sinon.spy()
-    const wrapper = shallow(<UserShow loadUser={callback} params={{ username: 'USER' }} />)
+    const wrapper = shallow(<UserShow loadUser={callback} user={{}} params={{ username: 'USER' }} />)
     expect(callback.calledOnce).to.be.true
   })
 })


### PR DESCRIPTION
- Add `eslint-plugin-import` settings to eslintrc
- Change a few eslint rules (see Rule Changes)
- Fix errors generated by rule changes

## Rule Changes
- Semicolon use generates an error
- Using forbidden prop types generates a warning
  - Forbidden prop types: `any`, `array`, `object`
  - This is a warning because prop types are going to be deprecated soon, and implementing such in-depth types is wasted work when they'll be implemented in Flow soon enough.
- Missing default props for required props generates an error
- Using a `map`/`forEach` index as a component key generates an error
  - This is recommended practice