### PR TITLE
Modify selectors to take entire state as first argument

### DIFF
--- a/src/components/projects/ProjectEdit/index.js
+++ b/src/components/projects/ProjectEdit/index.js
@@ -27,7 +27,7 @@ export class ProjectEdit extends Component {
 }
 
 const mapStateToProps = (state, { params }) => ({
-  initialValues: project(state.data.projects, params.key)
+  initialValues: project(state, params.key)
 })
 
 export default withRouter(connect(

--- a/src/components/projects/ProjectList/index.js
+++ b/src/components/projects/ProjectList/index.js
@@ -64,7 +64,7 @@ class ProjectList extends Component {
 export { ProjectList }
 
 const mapStateToProps = state => ({
-  projects: projects(state.data.projects),
+  projects: projects(state),
 })
 
 export default connect(

--- a/src/components/projects/ProjectShow/index.js
+++ b/src/components/projects/ProjectShow/index.js
@@ -28,7 +28,7 @@ export class ProjectShow extends Component {
 }
 
 const mapStateToProps = (state, { params }) => ({
-  project: project(state.data.projects, params.key)
+  project: project(state, params.key)
 })
 
 export default withRouter(connect(

--- a/src/components/teams/TeamEdit/index.js
+++ b/src/components/teams/TeamEdit/index.js
@@ -27,7 +27,7 @@ export class TeamEdit extends Component {
 }
 
 const mapStateToProps = (state, { params }) => ({
-  initialValues: team(state.data.teams, params.name)
+  initialValues: team(state, params.name)
 })
 
 export default withRouter(connect(

--- a/src/components/teams/TeamList/index.js
+++ b/src/components/teams/TeamList/index.js
@@ -67,7 +67,7 @@ class TeamList extends Component {
 export { TeamList }
 
 const mapStateToProps = state => ({
-  teams: teams(state.data.teams),
+  teams: teams(state),
 })
 
 export default connect(

--- a/src/components/teams/TeamShow/index.js
+++ b/src/components/teams/TeamShow/index.js
@@ -28,7 +28,7 @@ export class TeamShow extends Component {
 }
 
 const mapStateToProps = (state, { params }) => ({
-  team: team(state.data.teams, params.name)
+  team: team(state, params.name)
 })
 
 export default withRouter(connect(

--- a/src/components/tickets/TicketEdit/index.js
+++ b/src/components/tickets/TicketEdit/index.js
@@ -28,7 +28,7 @@ export class TicketEdit extends Component {
 
 const mapStateToProps = (state, { params }) => {
   return {
-    initialValues: ticket(state.data.tickets, params.key),
+    initialValues: ticket(state, params.key),
   }
 }
 

--- a/src/components/tickets/TicketList/index.js
+++ b/src/components/tickets/TicketList/index.js
@@ -66,7 +66,7 @@ export class TicketList extends Component {
 }
 
 const mapStateToProps = state => ({
-  tickets: tickets(state.data.tickets),
+  tickets: tickets(state),
 })
 
 export default connect(

--- a/src/components/tickets/TicketShow/index.js
+++ b/src/components/tickets/TicketShow/index.js
@@ -28,7 +28,7 @@ export class TicketShow extends Component {
 }
 
 const mapStateToProps = (state, { params }) => ({
-  ticket: ticket(state.data.tickets, params.key),
+  ticket: ticket(state, params.key),
 })
 
 export default withRouter(connect(

--- a/src/components/users/UserList/index.js
+++ b/src/components/users/UserList/index.js
@@ -62,7 +62,7 @@ export class UserList extends Component {
 }
 
 const mapStateToProps = state => ({
-  users: users(state.data.users),
+  users: users(state),
 })
 
 export default connect(

--- a/src/components/users/UserShow/index.js
+++ b/src/components/users/UserShow/index.js
@@ -27,8 +27,8 @@ export class UserShow extends Component {
 }
 
 const mapStateToProps = (state, { params }) => ({
-  user: user(state.data.users, params.username),
-  loading: fetching(state.data.users),
+  user: user(state, params.username),
+  loading: fetching(state),
 })
 
 export default withRouter(connect(

--- a/src/modules/comment.js
+++ b/src/modules/comment.js
@@ -80,10 +80,10 @@ export const reducer = createReducer(INITIAL_STATE, {
 
 /* SELECTORS */
 
-export const comment = (state, id) => state.byId[String(id)]
+export const comment = (state, id) => state.data.comments.byId[String(id)]
 
 export const comments = (state, ids) => {
-  let commentIds = state.ids
+  let commentIds = state.data.comments.ids
 
   if (ids) {
     commentIds = commentIds.filter(i => ids.includes(i))
@@ -92,6 +92,6 @@ export const comments = (state, ids) => {
   return commentIds.map(i => comment(state, i))
 }
 
-export const fetching = state => state.fetching
+export const fetching = state => state.data.comments.fetching
 
-export const error = state => state.error
+export const error = state => state.data.comments.error

--- a/src/modules/project.js
+++ b/src/modules/project.js
@@ -80,10 +80,10 @@ export const reducer = createReducer(INITIAL_STATE, {
 
 /* SELECTORS */
 
-export const project = (state, key) => state.byKey[key]
+export const project = (state, key) => state.data.projects.byKey[key]
 
 export const projects = (state, keys) => {
-  let projectKeys = state.keys
+  let projectKeys = state.data.projects.keys
 
   if (keys) {
     projectKeys = projectKeys.filter(k => keys.includes(k))
@@ -92,6 +92,6 @@ export const projects = (state, keys) => {
   return projectKeys.map(k => project(state, k)) || []
 }
 
-export const fetching = state => state.fetching
+export const fetching = state => state.data.projects.fetching
 
-export const error = state => state.error
+export const error = state => state.data.projects.error

--- a/src/modules/team.js
+++ b/src/modules/team.js
@@ -80,10 +80,10 @@ export const reducer = createReducer(INITIAL_STATE, {
 
 /* SELECTORS */
 
-export const team = (state, name) => state.byName[name]
+export const team = (state, name) => state.data.teams.byName[name]
 
 export const teams = (state, names) => {
-  let teamNames = state.names
+  let teamNames = state.data.teams.names
 
   if (names) {
     teamNames = teamNames.filter(n => names.includes(n))
@@ -92,6 +92,6 @@ export const teams = (state, names) => {
   return teamNames.map(n => team(state, n)) || []
 }
 
-export const fetching = state => state.fetching
+export const fetching = state => state.data.teams.fetching
 
-export const error = state => state.error
+export const error = state => state.data.teams.error

--- a/src/modules/ticket.js
+++ b/src/modules/ticket.js
@@ -79,10 +79,10 @@ export const reducer = createReducer(INITIAL_STATE, {
 
 /* SELECTORS */
 
-export const ticket = (state, key) => state.byKey[key]
+export const ticket = (state, key) => state.data.tickets.byKey[key]
 
 export const tickets = (state, keys) => {
-  let ticketKeys = state.keys
+  let ticketKeys = state.data.tickets.keys
 
   if (keys) {
     ticketKeys = ticketKeys.filter(k => keys.includes(k))
@@ -91,6 +91,6 @@ export const tickets = (state, keys) => {
   return ticketKeys.map(k => ticket(state, k)) || []
 }
 
-export const fetching = state => state.fetching
+export const fetching = state => state.data.tickets.fetching
 
-export const error = state => state.error
+export const error = state => state.data.tickets.error

--- a/src/modules/user.js
+++ b/src/modules/user.js
@@ -80,10 +80,10 @@ export const reducer = createReducer(INITIAL_STATE, {
 
 /* SELECTORS */
 
-export const user = (state, username) => state.byUsername[username]
+export const user = (state, username) => state.data.users.byUsername[username]
 
 export const users = (state, usernames) => {
-  let stateUsernames = state.usernames
+  let stateUsernames = state.data.users.usernames
 
   if (usernames) {
     stateUsernames = stateUsernames.filter(u => usernames.includes(u))
@@ -92,6 +92,6 @@ export const users = (state, usernames) => {
   return stateUsernames.map(u => user(state, u)) || []
 }
 
-export const fetching = state => state.fetching
+export const fetching = state => state.data.users.fetching
 
-export const error = state => state.error
+export const error = state => state.data.users.error

--- a/test/modules/comment_spec.js
+++ b/test/modules/comment_spec.js
@@ -65,27 +65,31 @@ describe('Comment - ', () => {
 
   describe('selectors', () => {
     const state = {
-      ids: [0, 1],
-      byId: {
-        '0': {
-          id: 0,
-          body: 'comment-0',
-        },
-        '1': {
-          id: 1,
-          body: 'comment-1'
-        },
-      },
-      fetching: true,
-      error: 'Error',
+      data: {
+        comments: {
+          ids: [0, 1],
+          byId: {
+            '0': {
+              id: 0,
+              body: 'comment-0',
+            },
+            '1': {
+              id: 1,
+              body: 'comment-1'
+            },
+          },
+          fetching: true,
+          error: 'Error',
+        }
+      }
     }
 
     it('comment', () => {
-      expect(comment(state, 0)).to.eq(state.byId['0'])
+      expect(comment(state, 0)).to.eq(state.data.comments.byId['0'])
     })
 
     it('comments', () => {
-      const expected = [state.byId['0'], state.byId['1']]
+      const expected = [state.data.comments.byId['0'], state.data.comments.byId['1']]
       expect(comments(state, [0, 1])).to.deep.eq(expected)
     })
 

--- a/test/modules/project_spec.js
+++ b/test/modules/project_spec.js
@@ -63,27 +63,31 @@ describe('Project - ', () => {
 
   describe('selectors', () => {
     const state = {
-      keys: ['PROJECT-0', 'PROJECT-1'],
-      byKey: {
-        'PROJECT-0': {
-          id: 0,
-          key: 'PROJECT-0',
-        },
-        'PROJECT-1': {
-          id: 1,
-          key: 'PROJECT-1'
-        },
-      },
-      fetching: true,
-      error: 'Error',
+      data: {
+        projects: {
+          keys: ['PROJECT-0', 'PROJECT-1'],
+          byKey: {
+            'PROJECT-0': {
+              id: 0,
+              key: 'PROJECT-0',
+            },
+            'PROJECT-1': {
+              id: 1,
+              key: 'PROJECT-1'
+            },
+          },
+          fetching: true,
+          error: 'Error',
+        }
+      }
     }
 
     it('project', () => {
-      expect(project(state, 'PROJECT-0')).to.eq(state.byKey['PROJECT-0'])
+      expect(project(state, 'PROJECT-0')).to.eq(state.data.projects.byKey['PROJECT-0'])
     })
 
     it('projects', () => {
-      const expected = [state.byKey['PROJECT-0'], state.byKey['PROJECT-1']]
+      const expected = [state.data.projects.byKey['PROJECT-0'], state.data.projects.byKey['PROJECT-1']]
       expect(projects(state, ['PROJECT-0', 'PROJECT-1'])).to.deep.eq(expected)
     })
 

--- a/test/modules/team_spec.js
+++ b/test/modules/team_spec.js
@@ -67,27 +67,31 @@ describe('Team - ', () => {
 
   describe('selectors', () => {
     const state = {
-      names: ['team0', 'team1'],
-      byName: {
-        'team0': {
-          id: 0,
-          name: 'team0',
-        },
-        'team1': {
-          id: 1,
-          name: 'team1'
-        },
-      },
-      fetching: true,
-      error: 'Error',
+      data: {
+        teams: {
+          names: ['team0', 'team1'],
+          byName: {
+            'team0': {
+              id: 0,
+              name: 'team0',
+            },
+            'team1': {
+              id: 1,
+              name: 'team1'
+            },
+          },
+          fetching: true,
+          error: 'Error',
+        }
+      }
     }
 
     it('team', () => {
-      expect(team(state, 'team0')).to.eq(state.byName['team0'])
+      expect(team(state, 'team0')).to.eq(state.data.teams.byName['team0'])
     })
 
     it('teams', () => {
-      const expected = [state.byName['team0'], state.byName['team1']]
+      const expected = [state.data.teams.byName['team0'], state.data.teams.byName['team1']]
       expect(teams(state, ['team0', 'team1'])).to.deep.eq(expected)
     })
 

--- a/test/modules/ticket_spec.js
+++ b/test/modules/ticket_spec.js
@@ -63,27 +63,31 @@ describe('Ticket - ', () => {
 
   describe('selectors', () => {
     const state = {
-      keys: ['TICKET-0', 'TICKET-1'],
-      byKey: {
-        'TICKET-0': {
-          id: 0,
-          key: 'TICKET-0',
-        },
-        'TICKET-1': {
-          id: 1,
-          key: 'TICKET-1'
-        },
-      },
-      fetching: true,
-      error: 'Error',
+      data: {
+        tickets: {
+          keys: ['TICKET-0', 'TICKET-1'],
+          byKey: {
+            'TICKET-0': {
+              id: 0,
+              key: 'TICKET-0',
+            },
+            'TICKET-1': {
+              id: 1,
+              key: 'TICKET-1'
+            },
+          },
+          fetching: true,
+          error: 'Error',
+        }
+      }
     }
 
     it('ticket', () => {
-      expect(ticket(state, 'TICKET-0')).to.eq(state.byKey['TICKET-0'])
+      expect(ticket(state, 'TICKET-0')).to.eq(state.data.tickets.byKey['TICKET-0'])
     })
 
     it('tickets', () => {
-      const expected = [state.byKey['TICKET-0'], state.byKey['TICKET-1']]
+      const expected = [state.data.tickets.byKey['TICKET-0'], state.data.tickets.byKey['TICKET-1']]
       expect(tickets(state, ['TICKET-0', 'TICKET-1'])).to.deep.eq(expected)
     })
 

--- a/test/modules/user_spec.js
+++ b/test/modules/user_spec.js
@@ -62,27 +62,31 @@ describe('User - ', () => {
 
   describe('selectors', () => {
     const state = {
-      usernames: ['user0', 'user1'],
-      byUsername: {
-        'user0': {
-          id: 0,
-          username: 'user0',
-        },
-        'user1': {
-          id: 1,
-          username: 'user1'
-        },
-      },
-      fetching: true,
-      error: 'Error',
+      data: {
+        users: {
+          usernames: ['user0', 'user1'],
+          byUsername: {
+            'user0': {
+              id: 0,
+              username: 'user0',
+            },
+            'user1': {
+              id: 1,
+              username: 'user1'
+            },
+          },
+          fetching: true,
+          error: 'Error',
+        }
+      }
     }
 
     it('user', () => {
-      expect(user(state, 'user0')).to.eq(state.byUsername['user0'])
+      expect(user(state, 'user0')).to.eq(state.data.users.byUsername['user0'])
     })
 
     it('users', () => {
-      const expected = [state.byUsername['user0'], state.byUsername['user1']]
+      const expected = [state.data.users.byUsername['user0'], state.data.users.byUsername['user1']]
       expect(users(state, ['user0', 'user1'])).to.deep.eq(expected)
     })
 


### PR DESCRIPTION
All selectors now take the full state as their first argument. This allows us to centralize knowledge about the state shape in the selectors so that if the state shape changes in the future, we only have to change the selectors.

An example of this is this change itself. In order to modify how the state is handled, I had to modify the selectors as well as 11 separate components. The components shouldn't have to care about how the state is shaped in any way.