### PR TITLE
Feature/prop types package

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "normalizr": "^3.2.1",
     "postcss-loader": "^0.13.0",
     "precss": "^1.4.0",
+    "prop-types": "^15.5.6",
     "react": "^15.4.1",
     "react-addons-css-transition-group": "^15.4.1",
     "react-addons-transition-group": "^15.4.1",

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react';
+import PropTypes from 'prop-types';
 import { Header, Footer } from 'components'
 
 const App = ({ children }) => (

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -1,5 +1,5 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import React from 'react'
+import PropTypes from 'prop-types'
 import { Header, Footer } from 'components'
 
 const App = ({ children }) => (

--- a/src/components/Root.js
+++ b/src/components/Root.js
@@ -1,5 +1,5 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import React from 'react'
+import PropTypes from 'prop-types'
 import { Provider } from 'react-redux'
 import { Router } from 'react-router'
 import routes from 'routes'

--- a/src/components/Root.js
+++ b/src/components/Root.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react';
+import PropTypes from 'prop-types';
 import { Provider } from 'react-redux'
 import { Router } from 'react-router'
 import routes from 'routes'

--- a/src/components/auth/Login/index.js
+++ b/src/components/auth/Login/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux'
 import { Field, reduxForm } from 'redux-form'
 import actions from 'modules/auth'
@@ -14,7 +15,7 @@ const LoginForm = ({ handleSubmit }) => (
 )
 
 LoginForm.propTypes = {
-  handleSubmit: React.PropTypes.func.isRequired,
+  handleSubmit: PropTypes.func.isRequired,
 }
 
 export { LoginForm }

--- a/src/components/auth/Login/index.js
+++ b/src/components/auth/Login/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { Field, reduxForm } from 'redux-form'
 import actions from 'modules/auth'

--- a/src/components/auth/LogoutLink/index.js
+++ b/src/components/auth/LogoutLink/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import actions from 'modules/auth'
 import { Button } from 'components'

--- a/src/components/auth/LogoutLink/index.js
+++ b/src/components/auth/LogoutLink/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux'
 import actions from 'modules/auth'
 import { Button } from 'components'
@@ -8,7 +9,7 @@ const LogoutLink = ({ logout }) => (
 )
 
 LogoutLink.propTypes = {
-  logout: React.PropTypes.func.isRequired,
+  logout: PropTypes.func.isRequired,
 }
 
 export default connect(null,

--- a/src/components/auth/Register/index.js
+++ b/src/components/auth/Register/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux'
 import { Field, reduxForm } from 'redux-form'
 import { renderField } from 'utils'
@@ -16,7 +17,7 @@ const RegisterForm = ({ handleSubmit }) => (
 )
 
 RegisterForm.propTypes = {
-  handleSubmit: React.PropTypes.func.isRequired,
+  handleSubmit: PropTypes.func.isRequired,
 }
 
 export { RegisterForm }

--- a/src/components/auth/Register/index.js
+++ b/src/components/auth/Register/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { Field, reduxForm } from 'redux-form'
 import { renderField } from 'utils'

--- a/src/components/auth/UserInfoBox/index.js
+++ b/src/components/auth/UserInfoBox/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { isLoggedIn, currentUser } from 'modules/auth'
 import { ProfileBox, LoginLink, RegisterLink } from 'components'

--- a/src/components/auth/UserInfoBox/index.js
+++ b/src/components/auth/UserInfoBox/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux'
 import { isLoggedIn, currentUser } from 'modules/auth'
 import { ProfileBox, LoginLink, RegisterLink } from 'components'
@@ -17,8 +18,8 @@ const UserInfoBox = ({ loggedIn, user }) => {
 }
 
 UserInfoBox.propTypes = {
-  loggedIn: React.PropTypes.bool,
-  user: React.PropTypes.object,
+  loggedIn: PropTypes.bool,
+  user: PropTypes.object,
 }
 
 UserInfoBox.defaultProps = {

--- a/src/components/layout/ProfileBox/index.js
+++ b/src/components/layout/ProfileBox/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types';
 import { LogoutLink } from 'components'
 
 const ProfileBox = ({ user }) => (
@@ -9,7 +10,7 @@ const ProfileBox = ({ user }) => (
 )
 
 ProfileBox.propTypes = {
-  user: React.PropTypes.object.isRequired,
+  user: PropTypes.object.isRequired,
 }
 
 export default ProfileBox

--- a/src/components/layout/ProfileBox/index.js
+++ b/src/components/layout/ProfileBox/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types'
 import { LogoutLink } from 'components'
 
 const ProfileBox = ({ user }) => (

--- a/src/components/misc/Button/index.js
+++ b/src/components/misc/Button/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types';
 import { Button as ButtonReactstrap } from 'reactstrap'
 
 const Button = ({ children, ...rest }) => (
@@ -8,7 +9,7 @@ const Button = ({ children, ...rest }) => (
 )
 
 Button.propTypes = {
-  children: React.PropTypes.node.isRequired,
+  children: PropTypes.node.isRequired,
 }
 
 export default Button

--- a/src/components/misc/Button/index.js
+++ b/src/components/misc/Button/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types'
 import { Button as ButtonReactstrap } from 'reactstrap'
 
 const Button = ({ children, ...rest }) => (

--- a/src/components/misc/DeleteButton/index.js
+++ b/src/components/misc/DeleteButton/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types'
 import { Button } from 'components'
 
 const DeleteButton = ({ handleClick }) => (

--- a/src/components/misc/DeleteButton/index.js
+++ b/src/components/misc/DeleteButton/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types';
 import { Button } from 'components'
 
 const DeleteButton = ({ handleClick }) => (
@@ -6,7 +7,7 @@ const DeleteButton = ({ handleClick }) => (
 )
 
 DeleteButton.propTypes = {
-  handleClick: React.PropTypes.func.isRequired,
+  handleClick: PropTypes.func.isRequired,
 }
 
 export default DeleteButton

--- a/src/components/misc/ErrorCard/index.js
+++ b/src/components/misc/ErrorCard/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types'
 import { Card, CardTitle, CardText } from 'reactstrap'
 
 const ErrorCard = ({ error }) => (

--- a/src/components/misc/ErrorCard/index.js
+++ b/src/components/misc/ErrorCard/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types';
 import { Card, CardTitle, CardText } from 'reactstrap'
 
 const ErrorCard = ({ error }) => (
@@ -11,7 +12,7 @@ const ErrorCard = ({ error }) => (
 )
 
 ErrorCard.propTypes = {
-  error: React.PropTypes.string.isRequired,
+  error: PropTypes.string.isRequired,
 }
 
 export default ErrorCard

--- a/src/components/misc/Flash/index.js
+++ b/src/components/misc/Flash/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types'
 
 const Flash = ({ message }) => {
   if (typeof message === 'object') {

--- a/src/components/misc/Flash/index.js
+++ b/src/components/misc/Flash/index.js
@@ -1,5 +1,7 @@
 import React from 'react'
 
+import PropTypes from 'prop-types';
+
 const Flash = ({ message }) => {
   if (typeof message === 'object') {
     return (
@@ -17,9 +19,9 @@ const Flash = ({ message }) => {
 }
 
 Flash.propTypes = {
-  message: React.PropTypes.oneOfType([
-    React.PropTypes.string,
-    React.PropTypes.object,
+  message: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object,
   ]).isRequired,
 }
 

--- a/src/components/misc/Gravatar/index.js
+++ b/src/components/misc/Gravatar/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types'
 import md5 from 'crypto-js/md5'
 
 const Gravatar = ({ email }) => {

--- a/src/components/misc/Gravatar/index.js
+++ b/src/components/misc/Gravatar/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types';
 import md5 from 'crypto-js/md5'
 
 const Gravatar = ({ email }) => {
@@ -15,7 +16,7 @@ const Gravatar = ({ email }) => {
 }
 
 Gravatar.propTypes = {
-  email: React.PropTypes.string.isRequired,
+  email: PropTypes.string.isRequired,
 }
 
 export default Gravatar

--- a/src/components/misc/LinkButton/index.js
+++ b/src/components/misc/LinkButton/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types'
 import { Link } from 'react-router'
 import { Button } from 'components'
 

--- a/src/components/misc/LinkButton/index.js
+++ b/src/components/misc/LinkButton/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types';
 import { Link } from 'react-router'
 import { Button } from 'components'
 
@@ -11,8 +12,8 @@ const LinkButton = ({ to, children, ...rest }) => (
 )
 
 LinkButton.propTypes = {
-  to: React.PropTypes.string.isRequired,
-  children: React.PropTypes.node.isRequired,
+  to: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
 }
 
 export default LinkButton

--- a/src/components/misc/NotFoundCard/index.js
+++ b/src/components/misc/NotFoundCard/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types'
 import { Card, CardTitle, CardText } from 'reactstrap'
 import { LinkButton } from 'components'
 

--- a/src/components/misc/NotFoundCard/index.js
+++ b/src/components/misc/NotFoundCard/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types';
 import { Card, CardTitle, CardText } from 'reactstrap'
 import { LinkButton } from 'components'
 
@@ -15,7 +16,7 @@ const NotFoundCard = ({ type }) => (
 )
 
 NotFoundCard.propTypes = {
-  type: React.PropTypes.string.isRequired,
+  type: PropTypes.string.isRequired,
 }
 
 export default NotFoundCard

--- a/src/components/projects/ProjectCard/index.js
+++ b/src/components/projects/ProjectCard/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types';
 import { Card, CardBlock, CardTitle, CardText } from 'reactstrap'
 import { ProjectDeleteButton, LinkButton, UserLink, NotFoundCard, ErrorCard } from 'components'
 
@@ -38,9 +39,9 @@ const ProjectCard = ({ project, error, loading }) => {
 }
 
 ProjectCard.propTypes = {
-  error: React.PropTypes.string,
-  project: React.PropTypes.object,
-  loading: React.PropTypes.bool,
+  error: PropTypes.string,
+  project: PropTypes.object,
+  loading: PropTypes.bool,
 }
 
 ProjectCard.defaultProps = {

--- a/src/components/projects/ProjectCard/index.js
+++ b/src/components/projects/ProjectCard/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types'
 import { Card, CardBlock, CardTitle, CardText } from 'reactstrap'
 import { ProjectDeleteButton, LinkButton, UserLink, NotFoundCard, ErrorCard } from 'components'
 

--- a/src/components/projects/ProjectDeleteButton/index.js
+++ b/src/components/projects/ProjectDeleteButton/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import actions from 'modules/project'
 import { DeleteButton } from 'components'

--- a/src/components/projects/ProjectDeleteButton/index.js
+++ b/src/components/projects/ProjectDeleteButton/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux'
 import actions from 'modules/project'
 import { DeleteButton } from 'components'
@@ -8,8 +9,8 @@ const ProjectDeleteButton = ({ project, deleteProject }) => (
 )
 
 ProjectDeleteButton.propTypes = {
-  project: React.PropTypes.object.isRequired,
-  deleteProject: React.PropTypes.func.isRequired,
+  project: PropTypes.object.isRequired,
+  deleteProject: PropTypes.func.isRequired,
 }
 
 export { ProjectDeleteButton }

--- a/src/components/projects/ProjectEdit/index.js
+++ b/src/components/projects/ProjectEdit/index.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import PropTypes from 'prop-types';
 import { withRouter } from 'react-router'
 import { connect } from 'react-redux'
 import actions, { project } from 'modules/project'
@@ -6,10 +7,10 @@ import { ProjectForm } from 'components'
 
 export class ProjectEdit extends Component {
   static propTypes = {
-    params: React.PropTypes.object.isRequired,
-    updateProject: React.PropTypes.func.isRequired,
-    loadProject: React.PropTypes.func.isRequired,
-    initialValues: React.PropTypes.object,
+    params: PropTypes.object.isRequired,
+    updateProject: PropTypes.func.isRequired,
+    loadProject: PropTypes.func.isRequired,
+    initialValues: PropTypes.object,
   }
 
   static defaultProps = {

--- a/src/components/projects/ProjectEdit/index.js
+++ b/src/components/projects/ProjectEdit/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types'
 import { withRouter } from 'react-router'
 import { connect } from 'react-redux'
 import actions, { project } from 'modules/project'

--- a/src/components/projects/ProjectForm/index.js
+++ b/src/components/projects/ProjectForm/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types';
 import { Field, reduxForm } from 'redux-form'
 import { renderField } from 'utils'
 import { Button } from 'reactstrap'
@@ -15,7 +16,7 @@ const ProjectNew = ({ handleSubmit }) => (
 )
 
 ProjectNew.propTypes = {
-  handleSubmit: React.PropTypes.func.isRequired,
+  handleSubmit: PropTypes.func.isRequired,
 }
 
 export default reduxForm({

--- a/src/components/projects/ProjectForm/index.js
+++ b/src/components/projects/ProjectForm/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types'
 import { Field, reduxForm } from 'redux-form'
 import { renderField } from 'utils'
 import { Button } from 'reactstrap'

--- a/src/components/projects/ProjectLink/index.js
+++ b/src/components/projects/ProjectLink/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types';
 import { Link } from 'react-router'
 
 const ProjectLink = ({ project, children }) => (
@@ -8,8 +9,8 @@ const ProjectLink = ({ project, children }) => (
 )
 
 ProjectLink.propTypes = {
-  project: React.PropTypes.object.isRequired,
-  children: React.PropTypes.node,
+  project: PropTypes.object.isRequired,
+  children: PropTypes.node,
 }
 
 ProjectLink.defaultProps = {

--- a/src/components/projects/ProjectLink/index.js
+++ b/src/components/projects/ProjectLink/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types'
 import { Link } from 'react-router'
 
 const ProjectLink = ({ project, children }) => (

--- a/src/components/projects/ProjectList/index.js
+++ b/src/components/projects/ProjectList/index.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux'
 import { Table } from 'reactstrap'
 import { ProjectLink, UserLink } from 'components'
@@ -42,13 +43,13 @@ export const ProjectTable = ({ projects: projectList }) => (
 )
 
 ProjectTable.propTypes = {
-  projects: React.PropTypes.array.isRequired,
+  projects: PropTypes.array.isRequired,
 }
 
 class ProjectList extends Component {
   static propTypes = {
-    projects: React.PropTypes.array.isRequired,
-    loadProjects: React.PropTypes.func.isRequired,
+    projects: PropTypes.array.isRequired,
+    loadProjects: PropTypes.func.isRequired,
   }
 
   componentWillMount() {

--- a/src/components/projects/ProjectList/index.js
+++ b/src/components/projects/ProjectList/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { Table } from 'reactstrap'
 import { ProjectLink, UserLink } from 'components'

--- a/src/components/projects/ProjectNew/index.js
+++ b/src/components/projects/ProjectNew/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux'
 import actions from 'modules/project'
 import { ProjectForm } from 'components'
@@ -8,7 +9,7 @@ export const ProjectNew = ({ createProject }) => (
 )
 
 ProjectNew.propTypes = {
-  createProject: React.PropTypes.func.isRequired,
+  createProject: PropTypes.func.isRequired,
 }
 
 export default connect(null,

--- a/src/components/projects/ProjectNew/index.js
+++ b/src/components/projects/ProjectNew/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import actions from 'modules/project'
 import { ProjectForm } from 'components'

--- a/src/components/projects/ProjectShow/index.js
+++ b/src/components/projects/ProjectShow/index.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import PropTypes from 'prop-types';
 import { withRouter } from 'react-router'
 import { connect } from 'react-redux'
 import actions, { project } from 'modules/project'
@@ -6,9 +7,9 @@ import { ProjectCard } from 'components'
 
 export class ProjectShow extends Component {
   static propTypes = {
-    params: React.PropTypes.object.isRequired,
-    loadProject: React.PropTypes.func.isRequired,
-    project: React.PropTypes.object.isRequired,
+    params: PropTypes.object.isRequired,
+    loadProject: PropTypes.func.isRequired,
+    project: PropTypes.object.isRequired,
   }
 
   componentWillMount() {

--- a/src/components/projects/ProjectShow/index.js
+++ b/src/components/projects/ProjectShow/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types'
 import { withRouter } from 'react-router'
 import { connect } from 'react-redux'
 import actions, { project } from 'modules/project'

--- a/src/components/teams/TeamCard/index.js
+++ b/src/components/teams/TeamCard/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types';
 import { Card, CardBlock, CardTitle, CardText } from 'reactstrap'
 import { LinkButton, TeamDeleteButton, UserLink, NotFoundCard, ErrorCard } from 'components'
 
@@ -41,9 +42,9 @@ const TeamCard = ({ team, loading, error }) => {
 }
 
 TeamCard.propTypes = {
-  team: React.PropTypes.object,
-  loading: React.PropTypes.bool,
-  error: React.PropTypes.string,
+  team: PropTypes.object,
+  loading: PropTypes.bool,
+  error: PropTypes.string,
 }
 
 TeamCard.defaultProps = {

--- a/src/components/teams/TeamCard/index.js
+++ b/src/components/teams/TeamCard/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types'
 import { Card, CardBlock, CardTitle, CardText } from 'reactstrap'
 import { LinkButton, TeamDeleteButton, UserLink, NotFoundCard, ErrorCard } from 'components'
 

--- a/src/components/teams/TeamDeleteButton/index.js
+++ b/src/components/teams/TeamDeleteButton/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import actions from 'modules/team'
 import { DeleteButton } from 'components'

--- a/src/components/teams/TeamDeleteButton/index.js
+++ b/src/components/teams/TeamDeleteButton/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux'
 import actions from 'modules/team'
 import { DeleteButton } from 'components'
@@ -8,8 +9,8 @@ const TeamDeleteButton = ({ team, deleteTeam }) => (
 )
 
 TeamDeleteButton.propTypes = {
-  team: React.PropTypes.object.isRequired,
-  deleteTeam: React.PropTypes.func.isRequired,
+  team: PropTypes.object.isRequired,
+  deleteTeam: PropTypes.func.isRequired,
 }
 
 export { TeamDeleteButton }

--- a/src/components/teams/TeamEdit/index.js
+++ b/src/components/teams/TeamEdit/index.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import PropTypes from 'prop-types';
 import { withRouter } from 'react-router'
 import { connect } from 'react-redux'
 import actions, { team } from 'modules/team'
@@ -6,10 +7,10 @@ import { TeamForm } from 'components'
 
 export class TeamEdit extends Component {
   static propTypes = {
-    params: React.PropTypes.object.isRequired,
-    loadTeam: React.PropTypes.func.isRequired,
-    updateTeam: React.PropTypes.func.isRequired,
-    initialValues: React.PropTypes.object,
+    params: PropTypes.object.isRequired,
+    loadTeam: PropTypes.func.isRequired,
+    updateTeam: PropTypes.func.isRequired,
+    initialValues: PropTypes.object,
   }
 
   static defaultProps = {

--- a/src/components/teams/TeamEdit/index.js
+++ b/src/components/teams/TeamEdit/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types'
 import { withRouter } from 'react-router'
 import { connect } from 'react-redux'
 import actions, { team } from 'modules/team'

--- a/src/components/teams/TeamForm/index.js
+++ b/src/components/teams/TeamForm/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types'
 import { Field, reduxForm } from 'redux-form'
 import { Button } from 'reactstrap'
 import { renderField } from 'utils'

--- a/src/components/teams/TeamForm/index.js
+++ b/src/components/teams/TeamForm/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types';
 import { Field, reduxForm } from 'redux-form'
 import { Button } from 'reactstrap'
 import { renderField } from 'utils'
@@ -22,7 +23,7 @@ const TeamForm = ({ handleSubmit }) => (
 )
 
 TeamForm.propTypes = {
-  handleSubmit: React.PropTypes.func.isRequired,
+  handleSubmit: PropTypes.func.isRequired,
 }
 
 export default reduxForm({

--- a/src/components/teams/TeamLink/index.js
+++ b/src/components/teams/TeamLink/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types';
 import { Link } from 'react-router'
 
 const TeamLink = ({ team, children }) => (
@@ -8,8 +9,8 @@ const TeamLink = ({ team, children }) => (
 )
 
 TeamLink.propTypes = {
-  team: React.PropTypes.object.isRequired,
-  children: React.PropTypes.node,
+  team: PropTypes.object.isRequired,
+  children: PropTypes.node,
 }
 
 TeamLink.defaultProps = {

--- a/src/components/teams/TeamLink/index.js
+++ b/src/components/teams/TeamLink/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types'
 import { Link } from 'react-router'
 
 const TeamLink = ({ team, children }) => (

--- a/src/components/teams/TeamList/index.js
+++ b/src/components/teams/TeamList/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { Table } from 'reactstrap'
 import actions, { teams } from 'modules/team'

--- a/src/components/teams/TeamList/index.js
+++ b/src/components/teams/TeamList/index.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux'
 import { Table } from 'reactstrap'
 import actions, { teams } from 'modules/team'
@@ -45,13 +46,13 @@ export const TeamTable = ({ teams: teamList }) => (
 )
 
 TeamTable.propTypes = {
-  teams: React.PropTypes.array.isRequired,
+  teams: PropTypes.array.isRequired,
 }
 
 class TeamList extends Component {
   static propTypes = {
-    loadTeams: React.PropTypes.func.isRequired,
-    teams: React.PropTypes.array.isRequired,
+    loadTeams: PropTypes.func.isRequired,
+    teams: PropTypes.array.isRequired,
   }
 
   componentWillMount() {

--- a/src/components/teams/TeamNew/index.js
+++ b/src/components/teams/TeamNew/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import actions from 'modules/team'
 import { TeamForm } from 'components'

--- a/src/components/teams/TeamNew/index.js
+++ b/src/components/teams/TeamNew/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux'
 import actions from 'modules/team'
 import { TeamForm } from 'components'
@@ -8,7 +9,7 @@ export const TeamNew = ({ createTeam }) => (
 )
 
 TeamNew.propTypes = {
-  createTeam: React.PropTypes.func.isRequired,
+  createTeam: PropTypes.func.isRequired,
 }
 
 export default connect(null,

--- a/src/components/teams/TeamShow/index.js
+++ b/src/components/teams/TeamShow/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types'
 import { withRouter } from 'react-router'
 import { connect } from 'react-redux'
 import actions, { team } from 'modules/team'

--- a/src/components/teams/TeamShow/index.js
+++ b/src/components/teams/TeamShow/index.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import PropTypes from 'prop-types';
 import { withRouter } from 'react-router'
 import { connect } from 'react-redux'
 import actions, { team } from 'modules/team'
@@ -6,9 +7,9 @@ import { TeamCard } from 'components'
 
 export class TeamShow extends Component {
   static propTypes = {
-    params: React.PropTypes.object.isRequired,
-    loadTeam: React.PropTypes.func.isRequired,
-    team: React.PropTypes.object.isRequired,
+    params: PropTypes.object.isRequired,
+    loadTeam: PropTypes.func.isRequired,
+    team: PropTypes.object.isRequired,
   }
 
   componentWillMount() {

--- a/src/components/tickets/TicketCard/index.js
+++ b/src/components/tickets/TicketCard/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types';
 import { Card, CardBlock, CardTitle, CardText } from 'reactstrap'
 import { LinkButton, UserLink, NotFoundCard, ErrorCard, TicketDeleteButton } from 'components'
 
@@ -43,9 +44,9 @@ const Ticket = ({ ticket, loading, error }) => {
 }
 
 Ticket.propTypes = {
-  ticket: React.PropTypes.object,
-  error: React.PropTypes.string,
-  loading: React.PropTypes.bool,
+  ticket: PropTypes.object,
+  error: PropTypes.string,
+  loading: PropTypes.bool,
 }
 
 Ticket.defaultProps = {

--- a/src/components/tickets/TicketCard/index.js
+++ b/src/components/tickets/TicketCard/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types'
 import { Card, CardBlock, CardTitle, CardText } from 'reactstrap'
 import { LinkButton, UserLink, NotFoundCard, ErrorCard, TicketDeleteButton } from 'components'
 

--- a/src/components/tickets/TicketDeleteButton/index.js
+++ b/src/components/tickets/TicketDeleteButton/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import actions from 'modules/ticket'
 import { DeleteButton } from 'components'

--- a/src/components/tickets/TicketDeleteButton/index.js
+++ b/src/components/tickets/TicketDeleteButton/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux'
 import actions from 'modules/ticket'
 import { DeleteButton } from 'components'
@@ -8,8 +9,8 @@ const TicketDeleteButton = ({ ticket, deleteTicket }) => (
 )
 
 TicketDeleteButton.propTypes = {
-  ticket: React.PropTypes.object.isRequired,
-  deleteTicket: React.PropTypes.func.isRequired,
+  ticket: PropTypes.object.isRequired,
+  deleteTicket: PropTypes.func.isRequired,
 }
 
 export { TicketDeleteButton }

--- a/src/components/tickets/TicketEdit/index.js
+++ b/src/components/tickets/TicketEdit/index.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import PropTypes from 'prop-types';
 import { withRouter } from 'react-router'
 import { connect } from 'react-redux'
 import actions, { ticket } from 'modules/ticket'
@@ -6,10 +7,10 @@ import { TicketForm } from 'components'
 
 export class TicketEdit extends Component {
   static propTypes = {
-    params: React.PropTypes.object.isRequired,
-    loadTicket: React.PropTypes.func.isRequired,
-    updateTicket: React.PropTypes.func.isRequired,
-    initialValues: React.PropTypes.object,
+    params: PropTypes.object.isRequired,
+    loadTicket: PropTypes.func.isRequired,
+    updateTicket: PropTypes.func.isRequired,
+    initialValues: PropTypes.object,
   }
 
   static defaultProps = {

--- a/src/components/tickets/TicketEdit/index.js
+++ b/src/components/tickets/TicketEdit/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types'
 import { withRouter } from 'react-router'
 import { connect } from 'react-redux'
 import actions, { ticket } from 'modules/ticket'

--- a/src/components/tickets/TicketForm/index.js
+++ b/src/components/tickets/TicketForm/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types'
 import { Field, reduxForm } from 'redux-form'
 import { Button } from 'reactstrap'
 import { renderField } from 'utils'

--- a/src/components/tickets/TicketForm/index.js
+++ b/src/components/tickets/TicketForm/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types';
 import { Field, reduxForm } from 'redux-form'
 import { Button } from 'reactstrap'
 import { renderField } from 'utils'
@@ -13,7 +14,7 @@ const TicketForm = ({ handleSubmit }) => (
 )
 
 TicketForm.propTypes = {
-  handleSubmit: React.PropTypes.func.isRequired,
+  handleSubmit: PropTypes.func.isRequired,
 }
 
 export default reduxForm({

--- a/src/components/tickets/TicketLink/index.js
+++ b/src/components/tickets/TicketLink/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types'
 import { Link } from 'react-router'
 
 const TicketLink = ({ ticket, children }) => (

--- a/src/components/tickets/TicketLink/index.js
+++ b/src/components/tickets/TicketLink/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types';
 import { Link } from 'react-router'
 
 const TicketLink = ({ ticket, children }) => (
@@ -8,8 +9,8 @@ const TicketLink = ({ ticket, children }) => (
 )
 
 TicketLink.propTypes = {
-  ticket: React.PropTypes.object.isRequired,
-  children: React.PropTypes.node,
+  ticket: PropTypes.object.isRequired,
+  children: PropTypes.node,
 }
 
 TicketLink.defaultProps = {

--- a/src/components/tickets/TicketList/index.js
+++ b/src/components/tickets/TicketList/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import actions, {
   tickets,

--- a/src/components/tickets/TicketList/index.js
+++ b/src/components/tickets/TicketList/index.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux'
 import actions, {
   tickets,
@@ -46,13 +47,13 @@ export const TicketTable = ({ tickets: ticketList }) => (
 )
 
 TicketTable.propTypes = {
-  tickets: React.PropTypes.array.isRequired,
+  tickets: PropTypes.array.isRequired,
 }
 
 export class TicketList extends Component {
   static propTypes = {
-    loadTickets: React.PropTypes.func.isRequired,
-    tickets: React.PropTypes.array.isRequired,
+    loadTickets: PropTypes.func.isRequired,
+    tickets: PropTypes.array.isRequired,
   }
 
   componentWillMount() {

--- a/src/components/tickets/TicketNew/index.js
+++ b/src/components/tickets/TicketNew/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import actions from 'modules/ticket'
 import { TicketForm } from 'components'

--- a/src/components/tickets/TicketNew/index.js
+++ b/src/components/tickets/TicketNew/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux'
 import actions from 'modules/ticket'
 import { TicketForm } from 'components'
@@ -8,7 +9,7 @@ export const TicketNew = ({ createTicket }) => (
 )
 
 TicketNew.propTypes = {
-  createTicket: React.PropTypes.func.isRequired,
+  createTicket: PropTypes.func.isRequired,
 }
 
 export default connect(null,

--- a/src/components/tickets/TicketShow/index.js
+++ b/src/components/tickets/TicketShow/index.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import PropTypes from 'prop-types';
 import { withRouter } from 'react-router'
 import { connect } from 'react-redux'
 import actions, { ticket } from 'modules/ticket'
@@ -6,9 +7,9 @@ import { TicketCard } from 'components'
 
 export class TicketShow extends Component {
   static propTypes = {
-    params: React.PropTypes.object.isRequired,
-    loadTicket: React.PropTypes.func.isRequired,
-    ticket: React.PropTypes.object.isRequired,
+    params: PropTypes.object.isRequired,
+    loadTicket: PropTypes.func.isRequired,
+    ticket: PropTypes.object.isRequired,
   }
 
   componentWillMount() {

--- a/src/components/tickets/TicketShow/index.js
+++ b/src/components/tickets/TicketShow/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types'
 import { withRouter } from 'react-router'
 import { connect } from 'react-redux'
 import actions, { ticket } from 'modules/ticket'

--- a/src/components/users/UserCard/index.js
+++ b/src/components/users/UserCard/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types';
 import { Card, CardBlock, CardTitle, CardText } from 'reactstrap'
 import { Gravatar, NotFoundCard, ErrorCard } from 'components'
 
@@ -32,9 +33,9 @@ const UserCard = ({ user, loading, error }) => {
 }
 
 UserCard.propTypes = {
-  user: React.PropTypes.object,
-  loading: React.PropTypes.bool,
-  error: React.PropTypes.string,
+  user: PropTypes.object,
+  loading: PropTypes.bool,
+  error: PropTypes.string,
 }
 
 UserCard.defaultProps = {

--- a/src/components/users/UserCard/index.js
+++ b/src/components/users/UserCard/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types'
 import { Card, CardBlock, CardTitle, CardText } from 'reactstrap'
 import { Gravatar, NotFoundCard, ErrorCard } from 'components'
 

--- a/src/components/users/UserLink/index.js
+++ b/src/components/users/UserLink/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types'
 import { Link } from 'react-router'
 
 const UserLink = ({ user, children }) => (

--- a/src/components/users/UserLink/index.js
+++ b/src/components/users/UserLink/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types';
 import { Link } from 'react-router'
 
 const UserLink = ({ user, children }) => (
@@ -8,8 +9,8 @@ const UserLink = ({ user, children }) => (
 )
 
 UserLink.propTypes = {
-  user: React.PropTypes.object.isRequired,
-  children: React.PropTypes.node,
+  user: PropTypes.object.isRequired,
+  children: PropTypes.node,
 }
 
 UserLink.defaultProps = {

--- a/src/components/users/UserList/index.js
+++ b/src/components/users/UserList/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { Table } from 'reactstrap'
 import actions, { users } from 'modules/user'

--- a/src/components/users/UserList/index.js
+++ b/src/components/users/UserList/index.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux'
 import { Table } from 'reactstrap'
 import actions, { users } from 'modules/user'
@@ -38,13 +39,13 @@ export const UserTable = ({ users: userList }) => {
 }
 
 UserTable.propTypes = {
-  users: React.PropTypes.array.isRequired,
+  users: PropTypes.array.isRequired,
 }
 
 export class UserList extends Component {
   static propTypes = {
-    loadUsers: React.PropTypes.func.isRequired,
-    users: React.PropTypes.array,
+    loadUsers: PropTypes.func.isRequired,
+    users: PropTypes.array,
   }
 
   static defaultProps = {

--- a/src/components/users/UserShow/index.js
+++ b/src/components/users/UserShow/index.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import PropTypes from 'prop-types';
 import { withRouter } from 'react-router'
 import { connect } from 'react-redux'
 import actions, { user, fetching } from 'modules/user'
@@ -10,10 +11,10 @@ export class UserShow extends Component {
   }
 
   static propTypes = {
-    params: React.PropTypes.object.isRequired,
-    loadUser: React.PropTypes.func.isRequired,
-    loading: React.PropTypes.bool,
-    user: React.PropTypes.object.isRequired,
+    params: PropTypes.object.isRequired,
+    loadUser: PropTypes.func.isRequired,
+    loading: PropTypes.bool,
+    user: PropTypes.object.isRequired,
   }
 
   componentWillMount() {

--- a/src/components/users/UserShow/index.js
+++ b/src/components/users/UserShow/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types'
 import { withRouter } from 'react-router'
 import { connect } from 'react-redux'
 import actions, { user, fetching } from 'modules/user'

--- a/src/utils/render-field.js
+++ b/src/utils/render-field.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types'
 import { FormGroup, Label, Input, FormText } from 'components/forms'
 
 const renderField = ({ input, label, type, meta: { touched, error, warning } }) => {

--- a/src/utils/render-field.js
+++ b/src/utils/render-field.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types';
 import { FormGroup, Label, Input, FormText } from 'components/forms'
 
 const renderField = ({ input, label, type, meta: { touched, error, warning } }) => {
@@ -21,13 +22,13 @@ const renderField = ({ input, label, type, meta: { touched, error, warning } }) 
 }
 
 renderField.propTypes = {
-  input: React.PropTypes.object.isRequired,
-  label: React.PropTypes.string.isRequired,
-  type: React.PropTypes.string.isRequired,
-  meta: React.PropTypes.shape({
-    touched: React.PropTypes.bool,
-    error: React.PropTypes.string,
-    warning: React.PropTypes.string,
+  input: PropTypes.object.isRequired,
+  label: PropTypes.string.isRequired,
+  type: PropTypes.string.isRequired,
+  meta: PropTypes.shape({
+    touched: PropTypes.bool,
+    error: PropTypes.string,
+    warning: PropTypes.string,
   }).isRequired
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2189,6 +2189,18 @@ fbjs@^0.8.1, fbjs@^0.8.4:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
 
+fbjs@^0.8.9:
+  version "0.8.12"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.12.tgz#10b5d92f76d45575fd63a217d4ea02bea2f8ed04"
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.9"
+
 figures@^1.3.5:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
@@ -4249,6 +4261,12 @@ promise@^7.1.1:
   resolved "https://registry.yarnpkg.com/promise/-/promise-7.1.1.tgz#489654c692616b8aa55b0724fa809bb7db49c5bf"
   dependencies:
     asap "~2.0.3"
+
+prop-types@^15.5.6:
+  version "15.5.6"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.6.tgz#797a915b1714b645ebb7c5d6cc690346205bd2aa"
+  dependencies:
+    fbjs "^0.8.9"
 
 proxy-addr@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
React.PropTypes is deprecated in 15.5 and has been moved to a separate package. This PR converts to prop-types.